### PR TITLE
Add 3 Linux Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,9 @@ An [awesome list](https://awesome.re) created and managed by the [Innovation Wor
 
 #### Linux
 - [turbostress](https://github.com/teads/turbostress) This tool generates load and outputs computer power metrics for this load.
+- [ipmitool](https://github.com/ipmitool/ipmitool) We can get the power consumption of a bare metal machine through the DCMI (IPMI extension).
+- [FreeIPMI](https://www.gnu.org/software/freeipmi/) We can get the power consumption of a bare metal machine through the DCMI (IPMI extension).
+- [PoweerTOP](https://01.org/powertop) A Linux tool to diagnose issues with power consumption and power management.
 
 #### Android
 


### PR DESCRIPTION
As the name suggests, ipmitool and FreeIPMI are tools for IPMI, but we
can also get the power consumption of a bare metal machine through DCMI
(IPMI extension).

PowerTOP is mainly for laptops, but it cat estimate the power
consumption of each process based on the battery discharge information
obtained by ACPI and Linux perf events etc.

I think these tools are useful, but please reject this PR if they don't
fit the purpose of this list.