### PR TITLE
Moving scaphandre to energy section instead of carbon

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,13 +43,13 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim any war
 
 #### Carbon
 - [Experiment Impact Tracker Library](https://github.com/Breakend/experiment-impact-tracker) Calculates carbon cost of ML job
-- [scaphandre](https://github.com/hubblo-org/scaphandre) Power measurement (bare metal hosts, prometheus, within a docker container, etc)
 
 #### Energy
 - [Beaker (Allen Institue For AI)](https://beaker.org) Captures GPU power inside a container
 - [carbontracker](https://github.com/lfwa/carbontracker) 
 - [RAPL in Action: Experiences in Using RAPL for Power Measurements](https://www.researchgate.net/publication/322308215_RAPL_in_Action_Experiences_in_Using_RAPL_for_Power_Measurements)
 - [Tool for tracking and predicting the energy consumption and carbon footprint of training deep learning models as described in Anthony et al. (2020)](https://arxiv.org/abs/2007.03051)
+- [scaphandre](https://github.com/hubblo-org/scaphandre) Power measurement (bare metal hosts, prometheus, within a docker container, etc)
 
 ### Cloud based
 

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,6 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim any war
 - [carbontracker](https://github.com/lfwa/carbontracker) 
 - [RAPL in Action: Experiences in Using RAPL for Power Measurements](https://www.researchgate.net/publication/322308215_RAPL_in_Action_Experiences_in_Using_RAPL_for_Power_Measurements)
 - [Tool for tracking and predicting the energy consumption and carbon footprint of training deep learning models as described in Anthony et al. (2020)](https://arxiv.org/abs/2007.03051)
-- [scaphandre](https://github.com/hubblo-org/scaphandre) Power measurement (bare metal hosts, prometheus, within a docker container, etc)
 
 ### Cloud based
 
@@ -68,6 +67,11 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim any war
 
 ### code based
 - [codecarbon.io](http://codecarbon.io/) Python : Track and reduce CO2 emissions from your computing
+
+### General purpose
+
+#### Energy
+- [scaphandre](https://github.com/hubblo-org/scaphandre) Power measurement (bare metal hosts, prometheus, within a docker container, etc)
 
 ### OS based
 


### PR DESCRIPTION
Hi !

Thanks for that awesome repo ;)

I'd like to suggest to move scaphandre to the energy category as it's limited to energy measurements (and it wont directly give carbon related metrics, event in the future, you know, UNIX philosophy, do one thing and do it well...)

I also noticed it's in the AI category. I'm not sure if this is accurate, I think you can use it to measure the impact of ML workloads, if those workloads are running on CPU and not GPU (as we don't include GPU measurements [yet](https://github.com/hubblo-org/scaphandre/issues/24)). But it's more like a general purpose tool to measure energy consumption on servers and the services running on them. I don't think however that it fits in the other categories (it should include windows support in a few months for example, so it wont be OS (linux) specific so long).

Anyway, I let you decide where you put it of course, it was just to clarify what the tool is and isn't.

Have a nice day !