### PR TITLE
Add PowerJoular and JoularJX power monitoring tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,11 +67,13 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim any war
 
 ### code based
 - [codecarbon.io](http://codecarbon.io/) Python : Track and reduce CO2 emissions from your computing
+- [JoularJX](https://gitlab.com/joular/joularjx) Java: Sotware power monitoring at the source code level in real time.
 
 ### General purpose
 
 #### Energy
 - [scaphandre](https://github.com/hubblo-org/scaphandre) Power measurement (bare metal hosts, prometheus, within a docker container, etc)
+- [PowerJoular](https://gitlab.com/joular/powerjoular) Monitor, in real time, the power consumption of software and hardware components.
 
 ### OS based
 


### PR DESCRIPTION
Hi, I'd like to add our two tools to monitor software and hardware power and energy.

- [PowerJoular](https://gitlab.com/joular/powerjoular): currently monitors CPU and GPU power consumption in real time, and soon we'll add support for some ARM processors too
- [JoularJX](https://gitlab.com/joular/joularjx): monitor power for individual methods in a Java application, also in real time.