### PR TITLE
Added Auto Scaling section with KEDA

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim any war
     - [AI](#ai)
         - [Carbon](#carbon)
         - [Energy](#energy)
+    - [Auto Scaling](#auto-scaling)
+        - [Kubernetes](#kubernetes)
     - [Cloud based](#cloud-based)
         - [AWS](#aws)
         - [Azure](#azure)
@@ -49,6 +51,11 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim any war
 - [carbontracker](https://github.com/lfwa/carbontracker) 
 - [RAPL in Action: Experiences in Using RAPL for Power Measurements](https://www.researchgate.net/publication/322308215_RAPL_in_Action_Experiences_in_Using_RAPL_for_Power_Measurements)
 - [Tool for tracking and predicting the energy consumption and carbon footprint of training deep learning models as described in Anthony et al. (2020)](https://arxiv.org/abs/2007.03051)
+
+### Auto Scaling
+
+#### Kubernetes
+- [KEDA](https://keda.sh/) can scale containers based on a wide range of events and supports scaling to zero.
 
 ### Cloud based
 


### PR DESCRIPTION
Hi,
first of all thanks for creating this list! I love it. 

I have a question. Are auto scaling tools within scope?

If so then I think [KEDA](https://keda.sh/) is a good candidate. It supports scaling based on a [wide range](https://keda.sh/docs/2.5/concepts/#event-sources-and-scalers) of events. As well as scaling to zero which is hard to do with the standard Kubernetes [HPA](https://github.com/kubernetes/kubernetes/issues/69687) (horizontal pod autoscaler).
