### PR TITLE
doc: Proposing PowerAPI as a Linux tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ An [awesome list](https://awesome.re) created and managed by the [Innovation Wor
 - [FreeIPMI](https://www.gnu.org/software/freeipmi/) We can get the power consumption of a bare metal machine through the DCMI (IPMI extension).
 - [ipmitool](https://github.com/ipmitool/ipmitool) We can get the power consumption of a bare metal machine through the DCMI (IPMI extension).
 - [PoweerTOP](https://01.org/powertop) A Linux tool to diagnose issues with power consumption and power management.
+- [PowerAPI](http://powerapi.org) A Linux software-defined power meter to estimate process-scale power consumption in real-time.
 - [turbostress](https://github.com/teads/turbostress) This tool generates load and outputs computer power metrics for this load.
 
 #### Web


### PR DESCRIPTION
PowerAPI is an open source toolkit to build software-defined power meters.