### PR TITLE
removing irrelevant organisations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Research, tools, code, libraries, and training for building applications that emit less carbon into our atmosphere.
 
-An [awesome list](https://awesome.re) created and managed by the [Innovation Working Group](https://greensoftware.foundation/working-groups/innovation) in the [greensoftware.foundation](https://greensoftware.foundation).
+An [awesome list](https://awesome.re) created and managed by the [Open Source Working Group](https://opensource.greensoftware.foundation) in the [Green Software Foundation](https://greensoftware.foundation).
 
 ## Disclaimer
 

--- a/readme.md
+++ b/readme.md
@@ -132,11 +132,9 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim any war
 - [Climate Change AI](https://www.climatechange.ai/)
 - [Green Software Design Community](https://www.GreenSoftwareDesign.com)
 - [Green Software Foundation](https://greensoftware.foundation)
-- [SolarWind Foundation](https://solarimpulse.com/)
 - [The Green Grid](https://www.thegreengrid.org/)
 - [The Green Web Foundation](https://www.thegreenwebfoundation.org/)
 - [TheShiftProject](https://theshiftproject.org/)
-- [TimeForThePlanet](https://www.time-planet.com/fr)
 
 ## Articles / Books / Research
 


### PR DESCRIPTION
Happy to be challenged on this, but I don't see how either of these organisations are specifically related to green software? if we open the list up to all green organisations, then clearly it would need to be much larger (and I don't see the value in that - we should focus on our area of expertise).