### PR TITLE
Removed duplication of section "Testing of Green Software"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -347,11 +347,6 @@ THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim any war
 - [Vessim: A Testbed for Carbon-Aware Applications and Systems.](https://arxiv.org/pdf/2306.09774.pdf)
 - [Software-in-the-Loop Simulation for Developing and Testing Carbon-Aware Applications.](https://doi.org/10.1002/spe.3275)
 
-#### Testing of Green Software
-
-- [Vessim: A Testbed for Carbon-Aware Applications and Systems.](https://arxiv.org/pdf/2306.09774.pdf)
-- [Software-in-the-Loop Simulation for Developing and Testing Carbon-Aware Applications.](https://doi.org/10.1002/spe.3275)
-
 #### Quantum Computing
 
 - [Is quantum computing green? An estimate for an energy-efficiency quantum advantage](https://arxiv.org/abs/2205.12092)


### PR DESCRIPTION
It seems like the section "Testing of Green Software" was accidentally added twice in the past. I removed one of them.

Before:
![image](https://github.com/user-attachments/assets/fdd302ff-80fe-44cd-99e8-376d4c57dfea)
 