### PR TITLE
Add ebb-ai to AI > Carbon — carbon-aware MCP scheduler

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ The Green Software Foundation Directory is designed to help developers, organiza
 ###### AI Carbon
 
 - [1ClickImpact](https://1clickimpact.com) API and platform for offsetting carbon emissions from AI workloads. Provides automated carbon offsetting and real-time tracking via a simple API. Connect with 1000+ apps using Zapier to automate carbon accounting and offsetting.
+- [ebb-ai](https://www.ebb-ai.com) Open-source MCP scheduler that defers non-urgent LLM tasks to the cleanest electricity-grid hour inside a deadline — 40-70% lower carbon per task. Multi-source live grid intensity (UK National Grid ESO, US EIA, ENTSO-E, Electricity Maps), per-task carbon receipts, Anthropic/OpenAI Batch API routing. Apache-2.0. [Source on GitHub](https://github.com/Vitalini/ebb-ai).
 - [Experiment Impact Tracker Library](https://github.com/Breakend/experiment-impact-tracker) Calculates carbon cost of ML job
 
 ###### AI Energy


### PR DESCRIPTION
Adds one entry to the **AI > Carbon** section.

### Entry

\`\`\`
- [ebb-ai](https://www.ebb-ai.com) Open-source MCP scheduler that defers non-urgent LLM tasks to the cleanest electricity-grid hour inside a deadline — 40-70% lower carbon per task. Multi-source live grid intensity (UK National Grid ESO, US EIA, ENTSO-E, Electricity Maps), per-task carbon receipts, Anthropic/OpenAI Batch API routing. Apache-2.0. [Source on GitHub](https://github.com/Vitalini/ebb-ai).
\`\`\`

### Why this fits AI > Carbon

The existing entries in this section are:
- **1ClickImpact** — carbon offsetting API for AI workloads (post-hoc compensation)
- **Experiment Impact Tracker Library** — measures ML training carbon (measurement)

ebb-ai is a **reduction-at-source** complement: it doesn't measure or offset, it shifts the dispatch time of deferrable LLM calls (overnight summaries, batch evaluations, scheduled research, document processing) to hours when the local electricity grid is cleaner. The 40-70% per-task savings come from intra-day grid-intensity variation alone, with no behaviour change required from the user — the project's auto-invocation skill lets the agent route any \"do this later\" / \"by tomorrow\" task automatically.

### Project facts

- Apache-2.0
- 204 passing tests (TypeScript + Python ports)
- 9 MCP tools, native plugins for Claude Code and OpenClaw, library mode for Node and Python
- Real grid feeds: UK National Grid ESO (key-less), US EIA, ENTSO-E, Electricity Maps (fallback)
- Live demo: https://www.ebb-ai.com — interactive best-window planner + 7-region carbon-intensity map

### Checklist

- [x] Alphabetical order (ebb-ai inserted before "Experiment Impact Tracker Library")
- [x] PR targets \`dev\` branch
- [x] Commit signed with DCO (\`Signed-off-by:\`)
- [x] No duplicates checked
- [x] Spelling and grammar reviewed