### PR TITLE
Add AXIOMAX ESG Carbon Shield under AI > Carbon

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ The Green Software Foundation Directory is designed to help developers, organiza
 ###### AI Carbon
 
 - [1ClickImpact](https://1clickimpact.com) API and platform for offsetting carbon emissions from AI workloads. Provides automated carbon offsetting and real-time tracking via a simple API. Connect with 1000+ apps using Zapier to automate carbon accounting and offsetting.
+- [AXIOMAX ESG Carbon Shield](https://axiomaxllc.com) Cryptographically verifiable carbon attestation tokens for AI inference workloads. ed25519-signed measurements, SHA-256 hash chain, independently auditable. Open-source verifier in Python/JS/Bash, browser-side mirror via Web Crypto API. Patent Pending USPTO 64/081,419. [[GitHub](https://github.com/axiomaxllc/esg-carbon-shield)]
 - [Experiment Impact Tracker Library](https://github.com/Breakend/experiment-impact-tracker) Calculates carbon cost of ML job
 
 ###### AI Energy


### PR DESCRIPTION
## What it adds

[AXIOMAX ESG Carbon Shield](https://axiomaxllc.com) — the first cryptographically verifiable carbon attestation system for AI inference workloads.

## Why it fits this list

Currently the `AI > Carbon` section has carbon offset/accounting tools but no cryptographically verifiable attestation system. AXIOMAX adds the verification layer:

- Every AI inference is measured locally on dedicated hardware
- SHA-256 hash chained per inference
- ed25519-signed periodic batches using client's private key
- Independent verification at public verifier without contacting AXIOMAX servers
- Open-source verifier in Python, JavaScript, and Bash + OpenSSL
- Browser-side mirror via Web Crypto API (no backend required)
- Patent Pending USPTO 64/081,419, filed June 3, 2026

## Links

- Main site: https://axiomaxllc.com
- Hosted verifier: https://verify.axiomaxllc.com
- Open-source repo: https://github.com/axiomaxllc/esg-carbon-shield
- Browser-side mirror: https://axiomaxllc.github.io/esg-carbon-shield/
- v1.0.0 release: https://github.com/axiomaxllc/esg-carbon-shield/releases/tag/v1.0.0

## License

MIT for verifier code. Architecture proprietary (Patent Pending).

## Why this matters for green software

CSRD (EU), SEC Climate Disclosure Rule (US), California SB 253 — all mandate independently verified sustainability data. For AI workloads specifically, current ESG software (Watershed, Persefoni, Sweep, Workiva) aggregates self-declared cloud provider numbers without cryptographic verification. AXIOMAX adds the missing layer.

Bootstrapped from Salinas, Puerto Rico. No external VC. Six USPTO patents in process.
