### PR TITLE
Articles: add Joule Wars — the AI race for useful intelligence per joule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,7 @@ The Green Software Foundation Directory is designed to help developers, organiza
 - [Beyond Single-Dimensional Metrics for Digital Sustainability](https://branch.climateaction.tech/issues/issue-3/beyond-single-dimensional-metrics-for-digital-sustainability/)
 - [Estimating the marginal carbon intensity of electricity with machine learning](https://www.tmrow.com/blog/marginal-carbon-intensity-of-electricity-with-machine-learning/)
 - [How to incorporate carbon-free energy for Google Cloud regions](https://cloud.google.com/sustainability/region-carbon)
+- [Joule Wars: the AI race for useful intelligence per joule](https://piszczek.pl/joule-wars)
 - [How we’re making Dropbox data centers 100% carbon neutral](https://dropbox.tech/infrastructure/making-dropbox-data-centers-carbon-neutral)
 - [Power consumption of JPEG, WebP, and AVIF](https://fershad.com/writing/power-consumption-jpeg-webp-and-avif)
 - [Software Carbon Intensity (Sci): Crafting A Standard](https://greensoftware.foundation/articles/software-carbon-intensity-crafting-a-standard)


### PR DESCRIPTION
Adds one entry to **Articles** (alphabetical order): [Joule Wars](https://piszczek.pl/joule-wars) — a definition-and-FAQ page (plus essay series) framing AI's energy problem as the industry's next competitive axis: capability is commoditizing, so the deciding metric becomes useful intelligence per joule. It complements the existing sustainability-metrics articles with the economic/competitive angle of energy-efficient AI. CC-BY-4.0, no paywall, no tracking.