### PR TITLE
Add MOOC Numérique Responsable to Courses

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -232,6 +232,7 @@ The Green Software Foundation Directory is designed to help developers, organiza
 - [The Principles of Sustainable Software Engineering](https://docs.microsoft.com/en-us/learn/modules/sustainable-software-engineering-overview/)
 - [Sustainable software engineering by openHPI](https://open.hpi.de/courses/sustainablesoftware2022)
 - [Harvard ENVR S-186: Enabling a Sustainable Digital Transformation](https://harvard.simplesyllabus.com/en-US/doc/554t3qmym)
+- [MOOC Numérique Responsable](https://gridboy.github.io/MOOC-Numerique-Responsable/) — Curated list of free MOOCs on responsible tech, green IT, and responsible AI (French/English)
 - [Curso de Desarrollo de software medioambientalmente sostenible (Green Software) Spanish](https://www.adrformacion.com/cursos/greensoft/greensoft.html)
 
 #### Articles / Books / Research


### PR DESCRIPTION
## Summary
- Adds [MOOC Numérique Responsable](https://gridboy.github.io/MOOC-Numerique-Responsable/) to the Courses section — a curated, actively maintained list of free MOOCs on responsible tech, green IT, and responsible AI (French/English/Belgian sources), sourced from institutions such as Inria, EPFL, Grenoble INP, Université de Liège, and UNESCO.
- All linked resources are free to access.

## Checklist
- [x] Added in alphabetical order within the Courses section
- [x] Title case format `[List Name](link)`
- [x] Commit signed off (DCO)